### PR TITLE
Update to use requests, hipchat v2 REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,13 @@ This plugin was created by the dev team at http://www.pricingassistant.com/ ; Co
 Install
 =======
 
-Copy hipchat.py next to your master.cfg file
+Install `requests` in your Python environment used by Buildbot
 
-Then in your master.cfg, add the following:
+```
+pip install requests
+```
+
+Copy hipchat.py next to your master.cfg file. Then in your master.cfg, add the following:
 
 ```
 import hipchat

--- a/README.md
+++ b/README.md
@@ -29,4 +29,11 @@ import hipchat
 c['status'].append(hipchat.HipChatStatusPush("YOUR_HIPCHAT_TOKEN", "HIPCHAT_ROOM_ID", localhost_replace="buildbot.mycompany.com"))
 ```
 
+There is also a parameter `mode` which allows to filter the messages. Currently supports `all`, `passing`, `warnings`, `failing` and `exception`, their semantics is similar to the MailNotifier Status plugin.
+
+```
+import hipchat
+c['status'].append(hipchat.HipChatStatusPush("YOUR_HIPCHAT_TOKEN", "HIPCHAT_ROOM_ID", mode='failing'))
+```
+
 Enjoy!


### PR DESCRIPTION
Hi, I've updated this plugin to use the `json` and `requests` modules, rather than shelling out to call `curl`. I also updated to the `v2` version of the HipChat API, and submitted the notification using JSON.
